### PR TITLE
Fixes #789

### DIFF
--- a/intermine/web/main/src/org/intermine/webservice/server/ServiceListingHandler.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/ServiceListingHandler.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.intermine.web.context.InterMineContext;
@@ -163,6 +165,7 @@ public class ServiceListingHandler extends DefaultHandler
             currentParam.put("Options", attrs.getValue("options"));
             currentParam.put("Recommended", "true".equals(attrs.getValue("recommended")));
             String defaultValue = attrs.getValue("default");
+            defaultValue = interpolateDefaultValues(defaultValue);
             if (defaultValue != null) {
                 currentParam.put("Default", defaultValue);
             }
@@ -181,6 +184,24 @@ public class ServiceListingHandler extends DefaultHandler
             returns.add(format);
         }
         sb = new StringBuffer();
+    }
+
+    private static final Pattern WEB_PROPS_INTERPOLATION_PATTERN =
+            Pattern.compile("\\{\\{([\\w\\.]+)\\}\\}");
+
+    private String interpolateDefaultValues(String defaultValue) {
+        if (defaultValue == null) {
+            return null;
+        }
+        Matcher m = WEB_PROPS_INTERPOLATION_PATTERN.matcher(defaultValue);
+        StringBuffer interpolated = new StringBuffer();
+        while (m.find()) {
+            String key = "services.defaults." + m.group(1);
+            String value = webProperties.getProperty(key, "");
+            m.appendReplacement(interpolated, value);
+        }
+        m.appendTail(interpolated);
+        return interpolated.toString();
     }
 
     @Override

--- a/intermine/web/main/src/org/intermine/webservice/server/ServicesListingsServlet.java
+++ b/intermine/web/main/src/org/intermine/webservice/server/ServicesListingsServlet.java
@@ -24,6 +24,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.intermine.web.context.InterMineContext;
 import org.intermine.web.logic.export.ResponseUtil;
 import org.intermine.webservice.server.exceptions.ServiceException;
 import org.intermine.webservice.server.output.Output;

--- a/intermine/webapp/main/resources/webapp/WEB-INF/web.xml
+++ b/intermine/webapp/main/resources/webapp/WEB-INF/web.xml
@@ -110,7 +110,7 @@
             of SQL; see the InterMine wiki for a full description of the query XML
             syntax.
         </description>
-        <param required="true" type="XML" schema="/schema/query.xsd" description="A definition of the query to execute in Path-Query XML format">query</param>
+        <param required="true" default="{{query}}" type="XML" schema="/schema/query.xsd" description="A definition of the query to execute in Path-Query XML format">query</param>
         <param type="Integer" required="false" default="2" min="1" max="2" description="The version of the XML format used">version</param>
         <param type="Integer" required="false" default="0" min="0" description="The index of the first result to return.">start</param>
         <param type="Integer" required="false" recommended="true" default="10" description="The maximum size of the result set.">size</param>

--- a/testmodel/webapp/main/resources/web.properties
+++ b/testmodel/webapp/main/resources/web.properties
@@ -26,3 +26,5 @@ begin.thirdBox.title = What is all this?
 begin.tabs.1.id = People
 begin.tabs.1.description = Get data on the people who work here
 begin.tabs.2.id = Entities
+
+services.defaults.query = <query model="testmodel" view="Company.name Company.department.name"/>


### PR DESCRIPTION
This allows default values in the services listing to support {{..}}
style patterns. The keys read from these patterns are replaces with
the values of `WEB_PROPERTIES["services.defaults." + key]`.